### PR TITLE
Fix RawKeyboard exception

### DIFF
--- a/lib/core/davinci_capture.dart
+++ b/lib/core/davinci_capture.dart
@@ -73,7 +73,7 @@ class DavinciCapture {
     final PipelineOwner pipelineOwner = PipelineOwner();
 
     /// create a new build owner
-    final BuildOwner buildOwner = BuildOwner();
+    final BuildOwner buildOwner = BuildOwner(focusManager: FocusManager());
 
     logicalSize ??= ui.window.physicalSize / ui.window.devicePixelRatio;
     imageSize ??= ui.window.physicalSize;


### PR DESCRIPTION
This pull request fixes #10. If we manually supply a `FocusManager` instance to `BuildOwner`, the system will not call `registerGlobalHandlers()` on it and therefore not try to override the global input event handler. This is explicitly stated in the documentation of `BuildOwner`:
"If the `focusManager` argument is not specified or is null, this will construct a new [FocusManager] and register its global input handlers via [FocusManager.registerGlobalHandlers], which will modify static state. **Callers wishing to avoid altering this state can explicitly pass a focus manager here.**"